### PR TITLE
Active true default, status no content para api de funcionário e empresa

### DIFF
--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -16,4 +16,8 @@ class Api::V1::ApiController < ActionController::API
   def bad_request
     render status: :bad_request, json: { errors: I18n.t('errors.bad_request') }
   end
+
+  def no_content
+    render status: :no_content, json: { errors: I18n.t('errors.no_content') }
+  end
 end

--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -2,6 +2,7 @@ class Api::V1::ApiController < ActionController::API
   rescue_from ActiveRecord::ActiveRecordError, with: :internet_server_error
   rescue_from ActiveRecord::RecordNotFound, with: :not_found
   rescue_from ActionController::ParameterMissing, with: :bad_request
+  rescue_from ActionController::MissingExactTemplate, with: :no_content
 
   private
 

--- a/app/controllers/api/v1/companies_controller.rb
+++ b/app/controllers/api/v1/companies_controller.rb
@@ -1,12 +1,14 @@
 class Api::V1::CompaniesController < Api::V1::ApiController
   def index
     companies = if params[:cnpj]
-                  Company.find_by(registration_number: params[:cnpj])
+                  Company.where(registration_number: params[:cnpj])
                 elsif params[:active]
                   Company.where(active: params[:active])
                 else
                   Company.all
                 end
+
+    return no_content if companies.empty?
 
     render status: :ok,
            json: companies.as_json(only: %i[id registration_number brand_name corporate_name active])

--- a/app/controllers/api/v1/companies_controller.rb
+++ b/app/controllers/api/v1/companies_controller.rb
@@ -8,10 +8,9 @@ class Api::V1::CompaniesController < Api::V1::ApiController
                   Company.all
                 end
 
-    return no_content if companies.empty?
+    return if companies.empty?
 
-    render status: :ok,
-           json: companies.as_json(only: %i[id registration_number brand_name corporate_name active])
+    render status: :ok, json: companies.as_json(only: %i[id registration_number brand_name corporate_name active])
   end
 
   def show

--- a/app/controllers/api/v1/employee_profiles_controller.rb
+++ b/app/controllers/api/v1/employee_profiles_controller.rb
@@ -8,6 +8,8 @@ class Api::V1::EmployeeProfilesController < Api::V1::ApiController
                           EmployeeProfile.all
                         end
 
+    return no_content if employee_profiles.empty?
+
     render status: :ok, json: format_employee_profile(employee_profiles)
   end
 

--- a/app/controllers/api/v1/employee_profiles_controller.rb
+++ b/app/controllers/api/v1/employee_profiles_controller.rb
@@ -8,9 +8,7 @@ class Api::V1::EmployeeProfilesController < Api::V1::ApiController
                           EmployeeProfile.all
                         end
 
-    return no_content if employee_profiles.empty?
-
-    render status: :ok, json: format_employee_profile(employee_profiles)
+    render status: :ok, json: format_employee_profile(employee_profiles) unless employee_profiles.empty?
   end
 
   private

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -5,6 +5,7 @@ pt-BR:
     internal_server_error: Erro interno do Servidor
     not_found: Página não encontrada
     bad_request: Erro nos parâmetros enviados
+    no_content: Nenhum conteúdo
     user:
       blocked_fail: Não foi possível bloquear o usuário
       unblocked_fail: Não foi possível desbloquear o usuário.
@@ -13,4 +14,3 @@ pt-BR:
     user:
       blocked: Usuário Bloqueado
       unblocked: Usuário Desbloqueado
-

--- a/db/migrate/20230623214303_add_default_to_company_active_status.rb
+++ b/db/migrate/20230623214303_add_default_to_company_active_status.rb
@@ -1,0 +1,5 @@
+class AddDefaultToCompanyActiveStatus < ActiveRecord::Migration[7.0]
+  def change
+    change_column_default :companies, :active, from: nil, to: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_21_001817) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_23_214303) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
-    t.integer "record_id", null: false
-    t.integer "blob_id", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
@@ -34,7 +34,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_21_001817) do
   end
 
   create_table "active_storage_variant_records", force: :cascade do |t|
-    t.integer "blob_id", null: false
+    t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
@@ -47,7 +47,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_21_001817) do
     t.string "phone_number"
     t.string "email"
     t.string "domain"
-    t.boolean "active"
+    t.boolean "active", default: true
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["registration_number"], name: "index_companies_on_registration_number", unique: true

--- a/spec/factories/companies.rb
+++ b/spec/factories/companies.rb
@@ -8,6 +8,5 @@ FactoryBot.define do
     email { 'contato@campuscode.com.br' }
     domain { 'campuscode.com.br' }
     logo { Rack::Test::UploadedFile.new(Rails.root.join('spec/support/images/logo.png'), 'image/png') }
-    active { true }
   end
 end

--- a/spec/models/company_spec.rb
+++ b/spec/models/company_spec.rb
@@ -34,4 +34,12 @@ RSpec.describe Company, type: :model do
       expect(other_company.errors[:registration_number]).to include 'já está em uso'
     end
   end
+
+  describe '#active' do
+    it 'é true por padrão' do
+      company = create(:company)
+
+      expect(company.active).to be true
+    end
+  end
 end

--- a/spec/requests/api/companies_api_spec.rb
+++ b/spec/requests/api/companies_api_spec.rb
@@ -23,13 +23,10 @@ describe 'Companies API' do
       expect(json_response[1]['active']).to eq true
     end
 
-    it 'e visualiza lista vazia' do
+    it 'retorna no_content quando a lista estiver vazia' do
       get '/api/v1/companies'
-      json_response = response.parsed_body
 
-      expect(response.status).to eq 200
-      expect(response.content_type).to include 'application/json'
-      expect(json_response).to eq []
+      expect(response.status).to eq 204
     end
 
     it 'e visualiza empresa pelo CNPJ' do
@@ -44,10 +41,10 @@ describe 'Companies API' do
 
       expect(response.status).to eq 200
       expect(response.content_type).to include 'application/json'
-      expect(json_response['brand_name']).to eq 'McDonalds'
-      expect(json_response['corporate_name']).to eq 'Arcos Dourados'
-      expect(json_response['id']).to eq company2.id
-      expect(json_response['active']).to eq true
+      expect(json_response[0]['brand_name']).to eq 'McDonalds'
+      expect(json_response[0]['corporate_name']).to eq 'Arcos Dourados'
+      expect(json_response[0]['id']).to eq company2.id
+      expect(json_response[0]['active']).to eq true
       expect(json_response).not_to include 'Campus Code'
       expect(json_response).not_to include 'Campus Code Treinamentos LTDA'
       expect(json_response).not_to include company1.id

--- a/spec/requests/api/companies_api_spec.rb
+++ b/spec/requests/api/companies_api_spec.rb
@@ -53,6 +53,29 @@ describe 'Companies API' do
       expect(json_response).not_to include company3.id
     end
 
+    it 'retorna no_content quando o CNPJ não é encontrado' do
+      company1 = create(:company, registration_number: '987654321', brand_name: 'Campus Code',
+                                  corporate_name: 'Campus Code Treinamentos LTDA')
+      company2 = create(:company, registration_number: '123456789', brand_name: 'McDonalds',
+                                  corporate_name: 'Arcos Dourados')
+      company3 = create(:company, registration_number: '567890123', brand_name: 'Apple', corporate_name: 'Maça de ouro')
+
+      get '/api/v1/companies?cnpj=12345678910'
+      json_response = response.parsed_body
+
+      expect(response.status).to eq 204
+      expect(json_response).not_to include 'McDonalds'
+      expect(json_response).not_to include 'Arcos Dourados'
+      expect(json_response).not_to include company2.id.to_s
+      expect(json_response).not_to include true.to_s
+      expect(json_response).not_to include 'Campus Code'
+      expect(json_response).not_to include 'Campus Code Treinamentos LTDA'
+      expect(json_response).not_to include company1.id.to_s
+      expect(json_response).not_to include 'Apple'
+      expect(json_response).not_to include 'Maça de ouro'
+      expect(json_response).not_to include company3.id.to_s
+    end
+
     it 'e visualiza empresa pelo status' do
       company = create(:company, registration_number: '987654321', brand_name: 'Campus Code',
                                  corporate_name: 'Campus Code Treinamentos LTDA', active: true)

--- a/spec/requests/api/employee_profile_api_spec.rb
+++ b/spec/requests/api/employee_profile_api_spec.rb
@@ -98,5 +98,11 @@ describe 'Employee Profiles API' do
       expect(json_response).not_to include '12117237045'
       expect(json_response).not_to include 'fired'
     end
+
+    it 'retorna no_content quando a lista estiver vazia' do
+      get '/api/v1/employee_profiles'
+
+      expect(response).to have_http_status(:no_content)
+    end
   end
 end

--- a/spec/requests/api/employee_profile_api_spec.rb
+++ b/spec/requests/api/employee_profile_api_spec.rb
@@ -102,7 +102,69 @@ describe 'Employee Profiles API' do
     it 'retorna no_content quando a lista estiver vazia' do
       get '/api/v1/employee_profiles'
 
-      expect(response).to have_http_status(:no_content)
+      expect(response.status).to eq 204
+    end
+
+    it 'retorna no_content quando o cpf não existe' do
+      company = create(:company)
+      company2 = create(:company, registration_number: '12345678901')
+      department = create(:department, company:)
+      department2 = create(:department, company: company2, code: 'XYZ456')
+      position = create(:position, department:)
+      position2 = create(:position, department: department2, code: 'POS999')
+      create(:employee_profile, name: 'Whitney Houston', cpf: '69142235219', status: 'unblocked',
+                                department: department2, position: position2)
+      create(:employee_profile, name: 'Beyonce Knowles', cpf: '66353795092', status: 'blocked', department:, position:)
+      create(:employee_profile, name: 'Michael Jackson', cpf: '12117237045', status: 'fired', department:, position:)
+
+      get '/api/v1/employee_profiles?cpf=66353795999'
+      json_response = response.parsed_body
+
+      expect(response.status).to eq 204
+      expect(json_response).not_to include 'Whitney Houston'
+      expect(json_response).not_to include '69142235219'
+      expect(json_response).not_to include 'unblocked'
+      expect(json_response).not_to include company2.registration_number
+      expect(json_response).not_to include 'Beyonce Knowles'
+      expect(json_response).not_to include '66353795092'
+      expect(json_response).not_to include 'blocked'
+      expect(json_response).not_to include company.registration_number
+      expect(json_response).not_to include 'Michael Jackson'
+      expect(json_response).not_to include '12117237045'
+      expect(json_response).not_to include 'fired'
+    end
+
+    it 'retorna no_content quando o status não existe' do
+      company = create(:company)
+      company2 = create(:company, registration_number: '12345678901')
+      department = create(:department, company:)
+      department2 = create(:department, company: company2, code: 'XYZ456')
+      position = create(:position, department:)
+      position2 = create(:position, department: department2, code: 'POS999')
+      create(:employee_profile, name: 'Whitney Houston', cpf: '69142235219', status: 'unblocked',
+                                department: department2, position: position2)
+      create(:employee_profile, name: 'Beyonce Knowles', cpf: '66353795092', status: 'blocked', department:, position:)
+      create(:employee_profile, name: 'Michael Jackson', cpf: '12117237045', status: 'fired', department:, position:)
+      create(:employee_profile, name: 'Lady Gaga', cpf: '12146825618', status: 'unblocked', department:, position:)
+
+      get '/api/v1/employee_profiles?status=unblock'
+      json_response = response.parsed_body
+
+      expect(response.status).to eq 204
+      expect(json_response).not_to include 'Whitney Houston'
+      expect(json_response).not_to include '69142235219'
+      expect(json_response).not_to include 'unblocked'
+      expect(json_response).not_to include company2.registration_number
+      expect(json_response).not_to include 'Lady Gaga'
+      expect(json_response).not_to include '12146825618'
+      expect(json_response).not_to include 'unblocked'
+      expect(json_response).not_to include company.registration_number
+      expect(json_response).not_to include 'Beyonce Knowles'
+      expect(json_response).not_to include '66353795092'
+      expect(json_response).not_to include 'blocked'
+      expect(json_response).not_to include 'Michael Jackson'
+      expect(json_response).not_to include '12117237045'
+      expect(json_response).not_to include 'fired'
     end
   end
 end


### PR DESCRIPTION
close #59 
Alterações pedidas pelas outras equipes: 
- Atributo active de company agora tem valor padrão => true;
- Endpoints de company e employee_profile retornam status no_content quando a pesquisa estiver vazia.